### PR TITLE
Update heapless version to remove requirement on removed feature const_fn

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,5 @@ edition = "2018"
 
 [dependencies]
 embedded-hal = "0.2.2"
-heapless =  { version = "0.4.2", features = ["const-fn"] }
+heapless = "0.5.3"
 crc_all = "0.1.0"


### PR DESCRIPTION
I updated `heapless` from version 0.4.2 to version 0.5.3. This removes the requirement for the feature `const_fn` which was removed. This allows the code to build on `rustc 1.54.0-nightly (ff2c947c0 2021-05-25)`.